### PR TITLE
Add hook for thread safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ SequelPaperTrail.info_for_paper_trail = { release: 'asdf131234', instance: `host
 
 SequelPaperTrail.info_for_paper_trail = -> { release: current_release }
 
-
 ```
 
 Note that if you use a lambda for whodunnit or info_for_paper_trail, you may run into errors with binding.  To fix that, you can do something like this:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Set whodunnit:
 
 SequelPaperTrail.whodunnit = 'Mr. Smith'
 
+# or if you are using a web server and want thread safety
+
+SequelPaperTrail.whodunnit = -> { req.env["USER_ID"] }
+
 ```
 
 Set info_for_paper_trail - additional info (Hash) which will be attached to versions table.
@@ -121,7 +125,24 @@ Set info_for_paper_trail - additional info (Hash) which will be attached to vers
 
 SequelPaperTrail.info_for_paper_trail = { release: 'asdf131234', instance: `hostname` }
 
+# or if you are using a web server and want thread safety
+
+SequelPaperTrail.info_for_paper_trail = -> { release: current_release }
+
+
 ```
+
+Note that if you use a lambda for whodunnit or info_for_paper_trail, you may run into errors with binding.  To fix that, you can do something like this:
+
+```
+
+```ruby
+
+this = self
+SequelPaperTrail.whodunnit = -> { this.current_user_id }
+
+```
+
 
 Development
 --------------
@@ -143,4 +164,3 @@ License
 --------------
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/sequel/plugins/has_paper_trail.rb
+++ b/lib/sequel/plugins/has_paper_trail.rb
@@ -100,15 +100,17 @@ module Sequel
       # rubocop:disable Style/Documentation
       module PaperTrailHelpers
         def self.create_version(model, attrs)
+          whodunnit = SequelPaperTrail.whodunnit.respond_to?(:call) ? instance_exec(&SequelPaperTrail.whodunnit) : SequelPaperTrail.whodunnit
           default_attrs = {
             item_type: model.paper_trail_item_class_name.to_s,
-            whodunnit: SequelPaperTrail.whodunnit,
+            whodunnit: whodunnit,
             created_at: Time.now.utc.iso8601,
             transaction_id: nil
           }
 
+          extra_params = SequelPaperTrail.info_for_paper_trail.respond_to?(:call) ? instance_exec(&SequelPaperTrail.info_for_paper_trail) : SequelPaperTrail.info_for_paper_trail
           create_attrs = default_attrs
-                         .merge(SequelPaperTrail.info_for_paper_trail)
+                         .merge(extra_params)
                          .merge(attrs)
 
           version_class(model.paper_trail_version_class_name).create(create_attrs)

--- a/lib/sequel/plugins/has_paper_trail.rb
+++ b/lib/sequel/plugins/has_paper_trail.rb
@@ -100,7 +100,7 @@ module Sequel
       # rubocop:disable Style/Documentation
       module PaperTrailHelpers
         def self.create_version(model, attrs)
-          whodunnit = SequelPaperTrail.whodunnit.respond_to?(:call) ? SequelPaperTrail.whodunnit.call : SequelPaperTrail.whodunnit
+          whodunnit = SequelPaperTrail.whodunnit.respond_to?(:call) ? instance_exec(&SequelPaperTrail.whodunnit) : SequelPaperTrail.whodunnit
           default_attrs = {
             item_type: model.paper_trail_item_class_name.to_s,
             whodunnit: whodunnit,
@@ -108,7 +108,7 @@ module Sequel
             transaction_id: nil
           }
 
-          extra_params = SequelPaperTrail.info_for_paper_trail.respond_to?(:call) ? SequelPaperTrail.info_for_paper_trail.call : SequelPaperTrail.info_for_paper_trail
+          extra_params = SequelPaperTrail.info_for_paper_trail.respond_to?(:call) ? instance_exec(&SequelPaperTrail.info_for_paper_trail) : SequelPaperTrail.info_for_paper_trail
           create_attrs = default_attrs
                          .merge(extra_params)
                          .merge(attrs)

--- a/lib/sequel/plugins/has_paper_trail.rb
+++ b/lib/sequel/plugins/has_paper_trail.rb
@@ -100,7 +100,7 @@ module Sequel
       # rubocop:disable Style/Documentation
       module PaperTrailHelpers
         def self.create_version(model, attrs)
-          whodunnit = SequelPaperTrail.whodunnit.respond_to?(:call) ? instance_exec(&SequelPaperTrail.whodunnit) : SequelPaperTrail.whodunnit
+          whodunnit = SequelPaperTrail.whodunnit.respond_to?(:call) ? SequelPaperTrail.whodunnit.call : SequelPaperTrail.whodunnit
           default_attrs = {
             item_type: model.paper_trail_item_class_name.to_s,
             whodunnit: whodunnit,
@@ -108,7 +108,7 @@ module Sequel
             transaction_id: nil
           }
 
-          extra_params = SequelPaperTrail.info_for_paper_trail.respond_to?(:call) ? instance_exec(&SequelPaperTrail.info_for_paper_trail) : SequelPaperTrail.info_for_paper_trail
+          extra_params = SequelPaperTrail.info_for_paper_trail.respond_to?(:call) ? SequelPaperTrail.info_for_paper_trail.call : SequelPaperTrail.info_for_paper_trail
           create_attrs = default_attrs
                          .merge(extra_params)
                          .merge(attrs)

--- a/lib/sequel/plugins/has_paper_trail.rb
+++ b/lib/sequel/plugins/has_paper_trail.rb
@@ -108,7 +108,14 @@ module Sequel
             transaction_id: nil
           }
 
-          extra_params = SequelPaperTrail.info_for_paper_trail.respond_to?(:call) ? SequelPaperTrail.info_for_paper_trail.call : SequelPaperTrail.info_for_paper_trail
+          extra_params = if SequelPaperTrail.info_for_paper_trail.nil?
+              {}
+            elsif SequelPaperTrail.info_for_paper_trail.respond_to?(:call)
+              SequelPaperTrail.info_for_paper_trail.call
+            else
+              SequelPaperTrail.info_for_paper_trail
+            end
+
           create_attrs = default_attrs
                          .merge(extra_params)
                          .merge(attrs)


### PR DESCRIPTION
Thanks for creating such a great gem @lazebny.  It's been really helpful.  We have 2 main web apps.  One is Rails and the other uses Cuba and Sequel.  We added paper_trail to the first one but had no answers for the second.  Your gem has made it possible for us to use paper_trail across both. 

We encountered a problem when implementing this gem.  Before, `SequelPaperTrail.whodunnit` and `SequelPaperTrail.info_for_paper_trail` were global and shared among all threads.  This is a problem in a web server that serves concurrent requests in separate threads:
1. Request 1 comes in on thread A for user Paul
2. Server sets SequelPaperTrail.whodunnit to 'Paul'
3. Request 2 comes in on thread B for user Amy
4. Server sets SequelPaperTrail.whodunnit to 'Amy'
5. Request 1 changes a model tracked in paper_trail
6. `versions` table gets a new record with whodunnit of 'Amy' and NOT 'Paul'.  

Corrupted data!  The regular paper_trail gem has a mechanism to bypass this.  So I did a quick fix, where `SequelPaperTrail.whodunnit` and `SequelPaperTrail.info_for_paper_trail` can also be a lambda or proc.

This allowed us to define a lambda that uses the current request as a context for getting the value for the current user ID.  No more corrupt data!

I hope you'll review and merge this PR and publish a new version.  Thanks!

 